### PR TITLE
Update params method to accept new ActionController::Parameters

### DIFF
--- a/app/controllers/shortener/shortened_urls_controller.rb
+++ b/app/controllers/shortener/shortened_urls_controller.rb
@@ -18,7 +18,7 @@ class Shortener::ShortenedUrlsController < ActionController::Base
         ActiveRecord::Base.connection.close
       end
 
-      params.except! *[:id, :action, :controller]
+      params.to_h.except! *[:id, :action, :controller]
       url = sl.url
 
       if params.present?

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -95,11 +95,11 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
   define_method CREATE_METHOD_NAME do
     count = 0
     begin
+      self.unique_key = generate_unique_key if unique_key.empty?
       super()
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::StatementInvalid => err
       if (count +=1) < 5
         logger.info("retrying with different unique key")
-        self.unique_key = generate_unique_key
         retry
       else
         logger.info("too many retries, giving up")

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -26,11 +26,12 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
     result = scope.where(url: clean_url(destination_url)).build(expires_at: nil)
 
     count = 0
-    begin
+    loop do
       count += 1
       raise "We never found a unique key... Why? #{result.unique_key} not unique" if count == 7
       result.unique_key = Shortener::ShortenedUrl.new.send(:generate_unique_key)
-    end while Shortener::ShortenedUrl.exists?(unique_key: result.unique_key)
+      break unless Shortener::ShortenedUrl.exists?(unique_key: result.unique_key)
+    end
   end
 
   # generate a shortened link from a url

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -110,7 +110,12 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
 
   def generate_unique_key
     charset = ::Shortener.key_chars
-    (0...::Shortener.unique_key_length).map{ charset[rand(charset.size)] }.join
+    key = nil
+    forbidden_keys_as_regex = /#{::Shortener.forbidden_keys.join("|")}/i
+    until key && (key =~ forbidden_keys_as_regex).nil?
+      key = (0...::Shortener.unique_key_length).map{ charset[rand(charset.size)] }.join
+    end
+    key
   end
 
 end

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -95,7 +95,7 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
   define_method CREATE_METHOD_NAME do
     count = 0
     begin
-      self.unique_key = generate_unique_key if unique_key.empty?
+      self.unique_key = generate_unique_key if unique_key.blank?
       super()
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::StatementInvalid => err
       if (count +=1) < 5


### PR DESCRIPTION
Taken from the latest version of the gem [here](https://github.com/jpmcgrath/shortener/blob/develop/app/models/shortener/shortened_url.rb#L99)
I didn't want to change too much at this stage, so just updated the line causing the error