### PR TITLE
Permit all query params on short urls before merging into existing param

### DIFF
--- a/app/controllers/shortener/shortened_urls_controller.rb
+++ b/app/controllers/shortener/shortened_urls_controller.rb
@@ -15,7 +15,7 @@ class Shortener::ShortenedUrlsController < ActionController::Base
       # browser type, ip address etc.
       sl.increment!(:use_count)
 
-      filtered_params = params.except *[:id, :action, :controller]
+      filtered_params = params.permit!.to_h.except *[:id, :action, :controller]
       url = sl.url
 
       if filtered_params.present?


### PR DESCRIPTION
Had a zoom call with @knightstick to discuss this solution. Deemed it suitable, since the params on the short-url are simply passed to the resolved url, and need no sanitization